### PR TITLE
feat: 검색 결과 화면 UI 및 진입 경로 처리 로직 구현

### DIFF
--- a/app/src/main/java/com/hjw0623/pyeonking/core/presentation/designsystem/util/BackTopBar.kt
+++ b/app/src/main/java/com/hjw0623/pyeonking/core/presentation/designsystem/util/BackTopBar.kt
@@ -1,39 +1,54 @@
 package com.hjw0623.pyeonking.core.presentation.designsystem.util
 
 import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
-
+import androidx.compose.foundation.layout.height
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
-import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.text.font.FontWeight
 
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun BackBar(
     onBackClick: () -> Unit,
+    title: String? = null,
     modifier: Modifier = Modifier
 ) {
-    Row(
+    Box(
         modifier = modifier
             .fillMaxWidth()
-            .background(MaterialTheme.colorScheme.background),
-        horizontalArrangement = Arrangement.Start,
+            .height(56.dp)
+            .background(MaterialTheme.colorScheme.background)
     ) {
-        IconButton(
-            onClick = onBackClick
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            modifier = Modifier.align(Alignment.CenterStart)
         ) {
-            Icon(
-                imageVector = Icons.AutoMirrored.Filled.ArrowBack,
-                contentDescription = null,
-                tint = MaterialTheme.colorScheme.primary
+            IconButton(onClick = onBackClick) {
+                Icon(
+                    imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.primary
+                )
+            }
+        }
+
+        title?.let {
+            Text(
+                text = it,
+                style = MaterialTheme.typography.titleMedium.copy(fontWeight = FontWeight.Bold),
+                color = MaterialTheme.colorScheme.onBackground,
+                modifier = Modifier.align(Alignment.Center)
             )
         }
     }

--- a/app/src/main/java/com/hjw0623/pyeonking/home/presentation/component/ProductCard.kt
+++ b/app/src/main/java/com/hjw0623/pyeonking/home/presentation/component/ProductCard.kt
@@ -27,7 +27,7 @@ import com.hjw0623.pyeonking.ui.theme.PyeonKingTheme
 
 @Composable
 fun ProductCardLarge(
-    recommendItem: Product,
+    product: Product,
     onCardClick: () -> Unit,
     modifier: Modifier = Modifier
 ) {
@@ -49,7 +49,7 @@ fun ProductCardLarge(
             contentAlignment = Alignment.Center
         ) {
             AsyncImage(
-                model = recommendItem.imgUrl,
+                model = product.imgUrl,
                 contentDescription = null,
                 modifier = Modifier.size(160.dp),
                 contentScale = ContentScale.Crop,
@@ -59,19 +59,19 @@ fun ProductCardLarge(
             modifier = Modifier
                 .padding(16.dp)
         ) {
-            ProductCardTextLarge(string = recommendItem.name)
-            ProductCardTextLarge(string = recommendItem.promotion)
+            ProductCardTextLarge(string = product.name)
+            ProductCardTextLarge(string = product.promotion)
             ProductCardTextLarge(
                 string = stringResource(
                     R.string.price_format,
-                    recommendItem.price,
-                    recommendItem.priceForEach
+                    product.price,
+                    product.priceForEach
                 )
             )
             ProductCardTextLarge(
-                string = recommendItem.brand,
+                string = product.brand,
                 color = getBrandColor(
-                    brand = recommendItem.brand,
+                    brand = product.brand,
                     isDarkTheme = isSystemInDarkTheme()
                 )
             )
@@ -85,7 +85,7 @@ private fun ProductCardPreview() {
     PyeonKingTheme {
         ProductCardLarge(
             onCardClick = {},
-            recommendItem = mockProduct
+            product = mockProduct
         )
     }
 }

--- a/app/src/main/java/com/hjw0623/pyeonking/home/presentation/component/RecommendSection.kt
+++ b/app/src/main/java/com/hjw0623/pyeonking/home/presentation/component/RecommendSection.kt
@@ -56,7 +56,7 @@ fun RecommendSection(
             ) {
                 ProductCardLarge(
                     onCardClick = { onCardClick(state.recommendList[it].name)},
-                    recommendItem = state.recommendList[it]
+                    product = state.recommendList[it]
                 )
             }
         }

--- a/app/src/main/java/com/hjw0623/pyeonking/search_result/data/SearchResultSource.kt
+++ b/app/src/main/java/com/hjw0623/pyeonking/search_result/data/SearchResultSource.kt
@@ -1,0 +1,5 @@
+package com.hjw0623.pyeonking.search_result.data
+
+enum class SearchResultSource {
+    TEXT, CAMERA
+}

--- a/app/src/main/java/com/hjw0623/pyeonking/search_result/presentation/SearchResultAction.kt
+++ b/app/src/main/java/com/hjw0623/pyeonking/search_result/presentation/SearchResultAction.kt
@@ -1,0 +1,8 @@
+package com.hjw0623.pyeonking.search_result.presentation
+
+import com.hjw0623.pyeonking.core.data.Product
+
+sealed interface SearchResultAction {
+    data object OnBackClick : SearchResultAction
+    data class OnProductClick(val item: Product) : SearchResultAction
+}

--- a/app/src/main/java/com/hjw0623/pyeonking/search_result/presentation/SearchResultScreen.kt
+++ b/app/src/main/java/com/hjw0623/pyeonking/search_result/presentation/SearchResultScreen.kt
@@ -1,0 +1,114 @@
+package com.hjw0623.pyeonking.search_result.presentation
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.hjw0623.pyeonking.R
+import com.hjw0623.pyeonking.core.data.mockProductList
+import com.hjw0623.pyeonking.core.presentation.designsystem.util.BackBar
+import com.hjw0623.pyeonking.home.presentation.component.ProductCardLarge
+import com.hjw0623.pyeonking.search_result.data.SearchResultSource
+import com.hjw0623.pyeonking.ui.theme.PyeonKingTheme
+
+@Composable
+fun SearchResultScreenRoot(
+    modifier: Modifier = Modifier,
+) {
+    var state by remember { mutableStateOf(SearchResultState()) }
+
+
+    SearchResultScreen(
+        state = state,
+        onAction = { action ->
+            when (action) {
+                SearchResultAction.OnBackClick -> {
+
+                }
+
+                is SearchResultAction.OnProductClick -> {
+
+                }
+            }
+        },
+        modifier = modifier
+    )
+}
+
+@Composable
+fun SearchResultScreen(
+    state: SearchResultState,
+    onAction: (SearchResultAction) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .background(MaterialTheme.colorScheme.background)
+    ) {
+        BackBar(
+            onBackClick = { onAction(SearchResultAction.OnBackClick) },
+            title = when (state.source) {
+                SearchResultSource.CAMERA -> stringResource(R.string.camera_search_result)
+                SearchResultSource.TEXT -> stringResource(R.string.search_result)
+            }
+        )
+
+        Text(
+            text = when (state.source) {
+                SearchResultSource.CAMERA -> ""
+                SearchResultSource.TEXT -> stringResource(
+                    R.string.search_result_title_with_query,
+                    state.passedQuery
+                )
+            },
+            style = MaterialTheme.typography.titleMedium,
+            modifier = Modifier.padding(16.dp)
+        )
+
+        LazyColumn(
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+            contentPadding = PaddingValues(horizontal = 16.dp, vertical = 8.dp),
+            modifier = Modifier.fillMaxSize()
+        ) {
+            items(
+                count = state.products.size,
+                key = { state.products[it].uuid }
+            ) {
+                ProductCardLarge(
+                    onCardClick = { onAction(SearchResultAction.OnProductClick(state.products[it])) },
+                    product = state.products[it]
+                )
+            }
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun SearchResultScreenPreview() {
+    PyeonKingTheme {
+        SearchResultScreen(
+            state = SearchResultState(
+                source = SearchResultSource.TEXT,
+                products = mockProductList,
+                passedQuery = "콜라"
+            ),
+            onAction = {}
+        )
+    }
+}

--- a/app/src/main/java/com/hjw0623/pyeonking/search_result/presentation/SearchResultState.kt
+++ b/app/src/main/java/com/hjw0623/pyeonking/search_result/presentation/SearchResultState.kt
@@ -1,0 +1,10 @@
+package com.hjw0623.pyeonking.search_result.presentation
+
+import com.hjw0623.pyeonking.core.data.Product
+import com.hjw0623.pyeonking.search_result.data.SearchResultSource
+
+data class SearchResultState(
+    val source: SearchResultSource = SearchResultSource.TEXT,
+    val products: List<Product> = emptyList(),
+    val passedQuery: String = ""
+)

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -26,5 +26,8 @@
     <string name="label_emart24">이마트24</string>
     <string name="label_seven_eleven">세븐일레븐</string>
     <string name="label_one_plus_one">1+1</string>
-    <string name="label_two_plus_one">2+1</string>"
+    <string name="label_two_plus_one">2+1</string>
+    <string name="camera_search_result">사진 검색 결과</string>
+    <string name="search_result">검색 결과</string>
+    <string name="search_result_title_with_query">\'%1$s\'에 대한 검색 결과</string>"
 </resources>


### PR DESCRIPTION
- `SearchResultSource` enum 추가
- 검색 진입 경로(TEXT, CAMERA)를 구분하여 UI 안내 문구에 반영
- 공통 UI 컴포넌트 재사용
- `BackBar` 수정 → 타이틀 포함 여부를 선택할 수 있도록 개선
- `ProductCardLarge`를 검색 결과 리스트에 적용
- PR 기준으로는 네비게이션 미적용 